### PR TITLE
Use dirname(@__FILE__) instead of Pkg.dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: julia
 julia:
   - nightly
+  - 0.5
   - 0.4
 os:
   - linux

--- a/test/wrapper.jl
+++ b/test/wrapper.jl
@@ -1,3 +1,3 @@
-dir = Pkg.dir("ROOT")
+dir = dirname(dirname(@__FILE__))
 cmd = "include(\"$(dir)/test/runtests.jl\")"
 run(`$(dir)/julia -e $cmd`)


### PR DESCRIPTION
This allows installing the package elsewhere.

Add testing against 0.5 to Travis - this runs the most
recent RC now, release once final tags are done.

Question: is running the tests twice on Travis intentional here?