### PR TITLE
More cosmetic and usability changes

### DIFF
--- a/deps/src/JlClasses_003.cxx
+++ b/deps/src/JlClasses_003.cxx
@@ -236,7 +236,7 @@ struct JlTDirectory: public Wrapper {
     DEBUG_MSG("Adding wrapper for TObject * TDirectory::Get(const char *) (" __HERE__ ")");
     // signature to use in the veto list: TObject * TDirectory::Get(const char *)
     // defined in /home/pgras/.julia/conda/3/include/TDirectory.h:203:24
-    t.method("Get", static_cast<TObject * (TDirectory::*)(const char *) >(&TDirectory::Get));
+    t.method("Get_", static_cast<TObject * (TDirectory::*)(const char *) >(&TDirectory::Get));
 
     DEBUG_MSG("Adding wrapper for TDirectory * TDirectory::GetDirectory(const char *, Bool_t, const char *) (" __HERE__ ")");
     // signature to use in the veto list: TDirectory * TDirectory::GetDirectory(const char *, Bool_t, const char *)

--- a/deps/src/JlClasses_004.cxx
+++ b/deps/src/JlClasses_004.cxx
@@ -494,7 +494,7 @@ struct JlTDirectoryFile: public Wrapper {
     DEBUG_MSG("Adding wrapper for TObject * TDirectoryFile::Get(const char *) (" __HERE__ ")");
     // signature to use in the veto list: TObject * TDirectoryFile::Get(const char *)
     // defined in /home/pgras/.julia/conda/3/include/TDirectoryFile.h:80:23
-    t.method("Get", static_cast<TObject * (TDirectoryFile::*)(const char *) >(&TDirectoryFile::Get));
+    t.method("Get_", static_cast<TObject * (TDirectoryFile::*)(const char *) >(&TDirectoryFile::Get));
 
     DEBUG_MSG("Adding wrapper for TDirectory * TDirectoryFile::GetDirectory(const char *, Bool_t, const char *) (" __HERE__ ")");
     // signature to use in the veto list: TDirectory * TDirectoryFile::GetDirectory(const char *, Bool_t, const char *)

--- a/examples/TTree_examples/read_tree1.jl
+++ b/examples/TTree_examples/read_tree1.jl
@@ -1,16 +1,15 @@
 using ROOT
-const R = ROOT
 
 println("Reading back the file created with write_tree1.jl using TTree::GetEntry.\n")
 
-f = R.TFile!Open("test1.root")
+f = ROOT.TFile!Open("test1.root")
 f != C_NULL || error("File not found.")
 
-t = R.GetTTree(f[], "tree")
+t = Get(f, "tree")
 t != C_NULL ||  error("Tree not found!")
 
-a = fill(0)
-SetBranchAddress(t[], "a", a)
+a = Ref{Int32}(0)
+SetBranchAddress(t, "a", a)
 nevts = GetEntries(t)
 for i in 1:nevts
     GetEntry(t, i-1)

--- a/examples/TTree_examples/read_tree3.jl
+++ b/examples/TTree_examples/read_tree3.jl
@@ -1,30 +1,29 @@
 using ROOT
-const R = ROOT
 
 println("Reading back the file created with write_tree3.jl using TTreeReader.\n")
 
-f = R.TFile!Open("test3.root")
+f = ROOT.TFile!Open("test3.root")
 f != C_NULL || error("File not found.")
 
-reader = R.TTreeReader("tree", f)
-Muon_pt_ = R.TTreeReaderArray{Float32}(reader, "Muon_pt")
-Muon_eta_ = R.TTreeReaderArray{Float32}(reader, "Muon_eta")
-Muon_phi_ = R.TTreeReaderArray{Float32}(reader, "Muon_phi")
+reader = ROOT.TTreeReader("tree", f)
+Muon_pt_ = ROOT.TTreeReaderArray{Float32}(reader, "Muon_pt")
+Muon_eta_ = ROOT.TTreeReaderArray{Float32}(reader, "Muon_eta")
+Muon_phi_ = ROOT.TTreeReaderArray{Float32}(reader, "Muon_phi")
 
 ievt = 0
 while Next(reader)
     global ievt += 1
     println("Event ", ievt)
 
-    println("Muon multiplicity: ", R.length(Muon_pt_))
+    println("Muon multiplicity: ", ROOT.length(Muon_pt_))
     
-    Muon_pt::Vector{Float32} = [ Muon_pt_[i-1] for i in 1:R.length(Muon_pt_)]
+    Muon_pt::Vector{Float32} = [ Muon_pt_[i-1] for i in 1:ROOT.length(Muon_pt_)]
     println("Muon pt: ", Muon_pt)
 
-    Muon_eta::Vector{Float32} = [ Muon_eta_[i-1] for i in 1:R.length(Muon_eta_)]
+    Muon_eta::Vector{Float32} = [ Muon_eta_[i-1] for i in 1:ROOT.length(Muon_eta_)]
     println("Muon eta: ", Muon_eta)
 
-    Muon_phi::Vector{Float32} = [ Muon_phi_[i-1] for i in 1:R.length(Muon_phi_)]
+    Muon_phi::Vector{Float32} = [ Muon_phi_[i-1] for i in 1:ROOT.length(Muon_phi_)]
     println("Muon phi: ", Muon_phi)
 
     println()

--- a/examples/TTree_examples/write_tree1.jl
+++ b/examples/TTree_examples/write_tree1.jl
@@ -1,12 +1,11 @@
 using ROOT
-const R = ROOT
 
 println("Creating a ROOT file with a TTree filled with scalars.\n")
 
 nevts = 10
-f = R.TFile!Open("test1.root", "RECREATE")
-t = R.TTree("tree", "tree")
-a = fill(0)
+f = ROOT.TFile!Open("test1.root", "RECREATE")
+t = ROOT.TTree("tree", "tree")
+a = Ref{Int32}(0)
 Branch(t, "a", a, Int32(32000), Int32(99))
 for i in 1:nevts
     a[] = i

--- a/examples/TTree_examples/write_tree3.jl
+++ b/examples/TTree_examples/write_tree3.jl
@@ -1,11 +1,10 @@
 using ROOT
-const R = ROOT
 using CxxWrap
 
 println("Creating a ROOT file with a TTree filled with std vectors.\n")
 
-f = R.TFile!Open("test3.root", "RECREATE")
-tree = R.TTree("tree", "tree")
+f = ROOT.TFile!Open("test3.root", "RECREATE")
+tree = ROOT.TTree("tree", "tree")
 
 Muon_pt = StdVector{Float32}()
 Muon_eta = StdVector{Float32}()

--- a/misc/ROOT.wit
+++ b/misc/ROOT.wit
@@ -9,11 +9,13 @@ out_cxx_dir         = "ROOT/deps/src"
 
 include_dirs        = [ "/home/pgras/.julia/conda/3/include", "src" ]
 
-input               = [ "TROOT.h", "TBrowser.h", "TTree.h", "TBranchPtr.h", "TLeaf.h", "TBranch.h", "TSystem.h", "TCanvas.h", "TH1.h", "TH2.h", "TProfile.h", "TProfile2D.h","TRandom.h", "TAxis.h", "TApplication.h",  "TDirectory.h", "TDirectoryFile.h", "TFile.h", "TNamed.h", "TObject.h", "TGraph.h", "TF1.h", "TTreeReader.h", "TTreeReaderValue.h", "TTreeReaderArray.h", "Templates.h", "TEntryList.h", "TKey.h",  "TVectorT.h", "TVectorDfwd.h", "TVectorFfwd.h", "Extra.h"  ]
-#input               = [  "TTreeReader.h", "TTreeReaderValue.h", "TTreeReaderArray.h" ]
+input               = [ "TROOT.h", "TBrowser.h", "TTree.h", "TBranchPtr.h", "TLeaf.h", "TBranch.h", "TSystem.h", "TCanvas.h", "TH1.h", "TH2.h", "TProfile.h", "TProfile2D.h","TRandom.h", "TAxis.h", "TApplication.h",  "TDirectory.h", "TDirectoryFile.h", "TFile.h", "TNamed.h", "TObject.h", "TGraph.h", "TF1.h", "TTreeReader.h", "TTreeReaderValue.h", "TTreeReaderArray.h", "Templates.h", "TEntryList.h", "TKey.h",  "TVectorT.h", "TVectorDfwd.h", "TVectorFfwd.h", "Extra.h" ]
+
 extra_headers       = [ "TVectorT.h" ]
 
 veto_list           = "src/jlROOT-veto.h"
+
+julia_names         = [ "TDirectoryFile::Get -> Get_", "TDirectory::Get -> Get_" ]
 
 fields_and_variables = true
 

--- a/src/ROOT-export.jl
+++ b/src/ROOT-export.jl
@@ -77,23 +77,23 @@ export GetTreeNumber, GetType, GetTypeName, GetUUID, GetUid, GetUniqueID, GetUpd
 export GetValue, GetValueLong64, GetValuePointer, GetVariable, GetVersion, GetVersionCode, GetVersionDate, GetVersionInt
 export GetVersionTime, GetVolumes, GetW, GetWebDisplay, GetWeight, GetWh, GetWindowHeight, GetWindowTopX, GetWindowTopY
 export GetWindowWidth, GetWorkingDirectory, GetWriteBasket, GetWw, GetX, GetXaxis, GetXbins, GetXmax, GetXmin, GetXsizeReal
-export GetXsizeUser, GetY, GetYaxis, GetYmax, GetYmin, GetYsizeReal, GetYsizeUser, GetZaxis, GetZipBytes, GetZmax, GetZmin, Getenv
-export GradientPar, HandleException, HandleIdleTimer, HandleInput, HandleTermInput, HandleTimer, HasInconsistentHash, HasMenuBar
-export Hash, Hide, HighlightConnect, Highlighted, HomeDirectory, HostName, Iconify, Idle, IgnoreInclude, IgnoreInterrupt
-export IgnoreSignal, Import, ImportAttributes, InControl, InPlaceClone, IncludeRange, IncrementPidOffset, IncrementProcessIDs
-export IncrementTotalBuffers, InheritsFrom, Init, InitArgs, InitExpo, InitGaus, InitPolynom, InitializeGraphics, InnerLoop, InputFiles
-export InsertPoint, InsertPointBefore, Inspect, Integral, IntegralAndError, IntegralError, IntegralFast, IntegralMultiple
-export IntegralOneDim, Interpolate, InvertBit, IsA, IsAbsoluteFileName, IsAlphanumeric, IsArchive, IsAutoDelete, IsBatch
-export IsBinOverflow, IsBinUnderflow, IsBinary, IsBuilt, IsChain, IsCmdThread, IsDestructed, IsDrawn, IsEditable, IsEqual, IsEscaped
-export IsEvalNormalized, IsExecutingMacro, IsFileInIncludePath, IsFolder, IsGrayscale, IsHighlight, IsInside, IsInterrupted, IsInvalid
-export IsLineProcessing, IsLinear, IsModified, IsOnHeap, IsOnTerminalBranch, IsOpen, IsPathLocal, IsProofServ, IsRange, IsRaw
-export IsRetained, IsRootFile, IsRunning, IsSortable, IsUnsigned, IsUpdated, IsValid, IsVariableBinSize, IsVectorized, IsWeb
-export IsWebDisplay, IsWebDisplayBatch, IsWritable, IsZombie, Keep, KeepCircular, KeyPressed, KolmogorovTest, LabelsDeflate
-export LabelsInflate, LabelsOption, Landau, LeastSquareFit, LeastSquareLinearFit, LineProcessed, Link, ListLibraries, ListSymbols
-export Load, LoadAllLibraries, LoadBaskets, LoadClass, LoadMacro, LoadTree, LoadTreeFriend, Lower, Macro, MakeClass
-export MakeCode, MakeDefCanvas, MakeDirectory, MakeFree, MakeProject, MakeProxy, MakeSelector, Map, Matches, MayNotUse, Mean
-export MemoryFull, Merge, Message, Moment, MoveOpaque, MovePoints, Multiply, MustClean, MustFlush, Next, NextTimeOut, NoLogOpt
-export NoLogoOpt, Notify, NotifyApplicationCreated, Now, Obsolete, OpaqueMoving, OpaqueResizing, Open, OpenConnection
+export GetXsizeUser, GetY, GetYaxis, GetYmax, GetYmin, GetYsizeReal, GetYsizeUser, GetZaxis, GetZipBytes, GetZmax, GetZmin, Get_
+export Getenv, GradientPar, HandleException, HandleIdleTimer, HandleInput, HandleTermInput, HandleTimer, HasInconsistentHash
+export HasMenuBar, Hash, Hide, HighlightConnect, Highlighted, HomeDirectory, HostName, Iconify, Idle, IgnoreInclude
+export IgnoreInterrupt, IgnoreSignal, Import, ImportAttributes, InControl, InPlaceClone, IncludeRange, IncrementPidOffset
+export IncrementProcessIDs, IncrementTotalBuffers, InheritsFrom, Init, InitArgs, InitExpo, InitGaus, InitPolynom, InitializeGraphics
+export InnerLoop, InputFiles, InsertPoint, InsertPointBefore, Inspect, Integral, IntegralAndError, IntegralError, IntegralFast
+export IntegralMultiple, IntegralOneDim, Interpolate, InvertBit, IsA, IsAbsoluteFileName, IsAlphanumeric, IsArchive, IsAutoDelete
+export IsBatch, IsBinOverflow, IsBinUnderflow, IsBinary, IsBuilt, IsChain, IsCmdThread, IsDestructed, IsDrawn, IsEditable
+export IsEqual, IsEscaped, IsEvalNormalized, IsExecutingMacro, IsFileInIncludePath, IsFolder, IsGrayscale, IsHighlight
+export IsInside, IsInterrupted, IsInvalid, IsLineProcessing, IsLinear, IsModified, IsOnHeap, IsOnTerminalBranch, IsOpen
+export IsPathLocal, IsProofServ, IsRange, IsRaw, IsRetained, IsRootFile, IsRunning, IsSortable, IsUnsigned, IsUpdated, IsValid
+export IsVariableBinSize, IsVectorized, IsWeb, IsWebDisplay, IsWebDisplayBatch, IsWritable, IsZombie, Keep, KeepCircular, KeyPressed
+export KolmogorovTest, LabelsDeflate, LabelsInflate, LabelsOption, Landau, LeastSquareFit, LeastSquareLinearFit, LineProcessed, Link
+export ListLibraries, ListSymbols, Load, LoadAllLibraries, LoadBaskets, LoadClass, LoadMacro, LoadTree, LoadTreeFriend, Lower, Macro
+export MakeClass, MakeCode, MakeDefCanvas, MakeDirectory, MakeFree, MakeProject, MakeProxy, MakeSelector, Map, Matches, MayNotUse
+export Mean, MemoryFull, Merge, Message, Moment, MoveOpaque, MovePoints, Multiply, MustClean, MustFlush, Next, NextTimeOut
+export NoLogOpt, NoLogoOpt, Notify, NotifyApplicationCreated, Now, Obsolete, OpaqueMoving, OpaqueResizing, Open, OpenConnection
 export OpenDirectory, OpenFile, OpenForumTopic, OpenGitHubIssue, OpenInBrowser, OpenPipe, OpenReferenceGuideFor, Openlog
 export OptimizeBaskets, OptimizeStorage, Paint, PaintGrapHist, PaintGraph, PaintStats, ParamsVec, Pick, Picked, Poisson, PoissonD, Pop
 export PrependPathName, Previous, Print, PrintCacheInfo, PrintCacheStats, PrintValue, Process, ProcessEvents, ProcessFile, ProcessLine

--- a/src/demo.jl
+++ b/src/demo.jl
@@ -4,14 +4,14 @@ function demo()
     println("""Executing:
 
    h = $(@__MODULE__).TH1D("h", "Normal distribution", 100, -5, 5)
-   $(@__MODULE__).FillRandom(h, "gaus")
+   FillRandom(h, "gaus")
    c = $(@__MODULE__).TCanvas()
-   $(@__MODULE__).Fit(h, "gaus")
+   Fit(h, "gaus")
    """)
     
-    h = TH1D("h", "Normal distribution", 100, -5, 5)
+    h = ROOT.TH1D("h", "Normal distribution", 100, -5, 5)
     FillRandom(h, "gaus")
-    c = TCanvas()
+    c = ROOT.TCanvas()
     Fit(h, "gaus")
     c
 end


### PR DESCRIPTION
Added extra usability functions: 
- GetObject(file::Union{ROOT.TDirectoryFile, CxxPtr{<:ROOT.TDirectoryFile}}, name::AbstractString)
- Base.getproperty(file::Union{ROOT.TDirectoryFile, CxxPtr{<:ROOT.TDirectoryFile}}, sym::Symbol)

This allows to get all sort of objects from a `TFile`
```julia
julia> f = ROOT.TFile!Open("demo_ROOT_out.root");

julia> @test GetObject(f,"h") isa ROOT.TH1
Test Passed

julia> f = ROOT.TFile!Open("test1.root")
CxxWrap.CxxWrapCore.CxxPtr{ROOT.TFile}(Ptr{ROOT.TFile} @0x000000012c833d20)

julia> @test f.tree isa ROOT.TTree
Test Passed

```